### PR TITLE
bug: untrack local xcode environment variables

### DIFF
--- a/Choreganizer/ios/.xcode.env.local
+++ b/Choreganizer/ios/.xcode.env.local
@@ -1,1 +1,0 @@
-export NODE_BINARY=/opt/homebrew/bin/node


### PR DESCRIPTION
The local xcode environment variables change the local setup. It should be gitignored AND untracked, since it was being tracked from a previous commit